### PR TITLE
Fix typo in details page

### DIFF
--- a/pages/pokemon/[id].js
+++ b/pages/pokemon/[id].js
@@ -23,7 +23,7 @@ const Details = ({ pokemon }) => {
                 <section className={styles.layout}>
                     <header>
                         <Image
-                            classname={styles.picture}
+                            className={styles.picture}
                             src={`https://pokemon-ssr.s3.sa-east-1.amazonaws.com/pokemon-main/${pokemon?.image}`}
                             alt={pokemon?.name}
                             width={500}


### PR DESCRIPTION
## Summary
- correct Image prop on Pokemon details page

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6879469a63448322bd8ab223e0fcd107